### PR TITLE
Removed 'page' from relative path 

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -13,7 +13,7 @@ const handler = NextAuth({
   adapter: PrismaAdapter(prisma) as Adapter,
   debug: true,
   pages: {
-    signIn: "../../../login/page",
+    signIn: "../../../login",
     verifyRequest: "../../../verify-request",
   },
   providers: [


### PR DESCRIPTION
This is a shot in the dark, but I'm receiving 404s for all pages.  This seems to be related to the `app` dir switch as there are many open GH issues and Stack Overflow posts about it.  No solid leads yet.