### PR TITLE
Hover and non-hover styling are now the same for current path

### DIFF
--- a/src/app/components/MainNavbar.tsx
+++ b/src/app/components/MainNavbar.tsx
@@ -25,9 +25,8 @@ const MainNavbar = ({ items }: MainNavbarProps) => {
           className={twMerge(
             "px-2.5 py-1 mx-1 rounded-full font-medium text-sm",
             item.href.endsWith(pathname)
-              ? "bg-indigo-500 text-white"
-              : "bg-white text-black",
-            "hover:bg-gray-200 hover:text-black"
+              ? "bg-indigo-500 text-white hover:bg-indigo-500 hover:text-white"
+              : "bg-white text-black hover:bg-gray-200 hover:text-black"
           )}
           href={item.href}
           key={idx}


### PR DESCRIPTION
The current path's Link button should not have the same behavior as the others.  It should only render it's selected state even when hovering (indigo background and white text).